### PR TITLE
Proposed fix for issue #38

### DIFF
--- a/src/main/java/org/jdatepicker/impl/JDatePanelImpl.java
+++ b/src/main/java/org/jdatepicker/impl/JDatePanelImpl.java
@@ -213,6 +213,15 @@ public class JDatePanelImpl extends JPanel implements JDatePanel {
         return ComponentManager.getInstance().getComponentColorDefaults();
     }
 
+    @Override
+    public void setVisible(boolean aFlag) {
+        super.setVisible(aFlag);
+
+        if (aFlag) {
+            internalView.updateTodayLabel();
+        }
+    }
+
     /**
      * Logically grouping the view controls under this internal class. 
      * 
@@ -382,6 +391,17 @@ public class JDatePanelImpl extends JPanel implements JDatePanel {
             return noneLabel;
         }
 
+        private void updateTodayLabel() {
+            try {
+                todayLabel.setText(getTexts().getText(
+                        ComponentTextDefaults.TODAY)
+                        + ": "
+                        + formatter.valueToString(Calendar.getInstance()));
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+
         /**
          * This method initializes todayLabel    
          *     
@@ -393,12 +413,7 @@ public class JDatePanelImpl extends JPanel implements JDatePanel {
                 todayLabel.setForeground(getColors().fgTodaySelector());
                 todayLabel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
                 todayLabel.addMouseListener(internalController);
-                try {
-                    todayLabel.setText(getTexts().getText(ComponentTextDefaults.TODAY) + ": " + formatter.valueToString(Calendar.getInstance()));
-                } 
-                catch (ParseException e) {
-                    e.printStackTrace();
-                }
+                updateTodayLabel();
             }
             return todayLabel;
         }
@@ -967,5 +982,4 @@ public class JDatePanelImpl extends JPanel implements JDatePanel {
         }
 
     }
-
 }


### PR DESCRIPTION
Override setVisible() Method of JDatePanel to update today label when the panel is about to be shown.
Closes #38.

@r-mattasa: Your fix only updates the label when you directly click on it. As I think this is not the optimal solution I went another way.