### PR TITLE
removed determination of type of model value through type passed to c…

### DIFF
--- a/src/main/java/org/jdatepicker/DateComponent.java
+++ b/src/main/java/org/jdatepicker/DateComponent.java
@@ -46,7 +46,7 @@ import java.util.Set;
  *
  * @author Juan Heyns
  */
-public interface DateComponent {
+public interface DateComponent<T> {
 
     /**
      * Returns the value of the currently represented date in the component.
@@ -58,7 +58,7 @@ public interface DateComponent {
      *
      * @return A new Model
      */
-    DateModel<?> getModel();
+    DateModel<T> getModel();
 
     /**
      * Adds an ActionListener. The actionListener is notified when a user clicks

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -27,7 +27,7 @@
  */
 package org.jdatepicker;
 
-public interface DatePanel extends DateComponent {
+public interface DatePanel<T> extends DateComponent<T> {
 
     /**
      * Sets the visibilty of the Year navigation buttons. Defaults to false.

--- a/src/main/java/org/jdatepicker/DatePicker.java
+++ b/src/main/java/org/jdatepicker/DatePicker.java
@@ -29,7 +29,7 @@ package org.jdatepicker;
 
 import javax.swing.*;
 
-public interface DatePicker extends DatePanel {
+public interface DatePicker<T> extends DatePanel<T> {
 
     /**
      * Is the text component editable or not. Defaults to false.

--- a/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/src/main/java/org/jdatepicker/JDatePanel.java
@@ -59,7 +59,7 @@ import java.util.*;
  * @author JC Oosthuizen
  * @author Yue Huang
  */
-public class JDatePanel extends JComponent implements DatePanel {
+public abstract class JDatePanel<T> extends JComponent implements DatePanel {
 
     private static final long serialVersionUID = -2299249311312882915L;
 
@@ -77,34 +77,6 @@ public class JDatePanel extends JComponent implements DatePanel {
      * Creates a JDatePanel with a default calendar model.
      */
     public JDatePanel() {
-        this(createModel());
-    }
-
-    /**
-     * Create a JDatePanel with an initial value, with a UtilCalendarModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePanel(Calendar value) {
-        this(createModelFromValue(value));
-    }
-
-    /**
-     * Create a JDatePanel with an initial value, with a UtilDateModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePanel(java.util.Date value) {
-        this(createModelFromValue(value));
-    }
-
-    /**
-     * Create a JDatePanel with an initial value, with a SqlDateModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePanel(java.sql.Date value) {
-        this(createModelFromValue(value));
     }
 
     /**
@@ -112,7 +84,7 @@ public class JDatePanel extends JComponent implements DatePanel {
      *
      * @param model a custom date model
      */
-    public JDatePanel(DateModel<?> model) {
+    public JDatePanel(DateModel<T> model) {
         actionListeners = new HashSet<ActionListener>();
         dateConstraints = new HashSet<DateSelectionConstraint>();
 
@@ -125,27 +97,6 @@ public class JDatePanel extends JComponent implements DatePanel {
 
         setLayout(new GridLayout(1, 1));
         add(internalView);
-    }
-
-    public static DateModel<Calendar> createModel() {
-        return new UtilCalendarModel();
-    }
-
-    private static DateModel<Calendar> createModel(Calendar value) {
-        return new UtilCalendarModel(value);
-    }
-
-    private static DateModel<?> createModelFromValue(Object value) {
-        if (value instanceof java.util.Calendar) {
-            return new UtilCalendarModel((Calendar) value);
-        }
-        if (value instanceof java.util.Date) {
-            return new UtilDateModel((java.util.Date) value);
-        }
-        if (value instanceof java.sql.Date) {
-            return new SqlDateModel((java.sql.Date) value);
-        }
-        throw new IllegalArgumentException("No model could be constructed from the initial value object.");
     }
 
     public void addActionListener(ActionListener actionListener) {
@@ -197,7 +148,7 @@ public class JDatePanel extends JComponent implements DatePanel {
     /* (non-Javadoc)
      * @see org.jdatepicker.JDateComponent#getModel()
      */
-    public DateModel<?> getModel() {
+    public DateModel<T> getModel() {
         return internalModel.getModel();
     }
 
@@ -923,18 +874,18 @@ public class JDatePanel extends JComponent implements DatePanel {
     protected class InternalCalendarModel implements TableModel, SpinnerModel, ChangeListener {
 
         private final int firstDayOfWeekOffset = Calendar.getInstance().getFirstDayOfWeek() - Calendar.SUNDAY;
-        private DateModel<?> model;
+        private DateModel<T> model;
         private Set<ChangeListener> spinnerChangeListeners;
         private Set<TableModelListener> tableModelListeners;
 
-        public InternalCalendarModel(DateModel<?> model) {
+        public InternalCalendarModel(DateModel<T> model) {
             this.spinnerChangeListeners = new HashSet<ChangeListener>();
             this.tableModelListeners = new HashSet<TableModelListener>();
             this.model = model;
             model.addChangeListener(this);
         }
 
-        public DateModel<?> getModel() {
+        public DateModel<T> getModel() {
             return model;
         }
 

--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -54,7 +54,7 @@ import java.util.Set;
  * @author JC Oosthuizen
  * @author Yue Huang
  */
-public class JDatePicker extends JComponent implements DatePicker {
+public abstract class JDatePicker<T> extends JComponent implements DatePicker {
 
     private static final long serialVersionUID = 2814777654384974503L;
 
@@ -62,51 +62,10 @@ public class JDatePicker extends JComponent implements DatePicker {
     private JFormattedTextField formattedTextField;
     private JButton button;
 
-    private JDatePanel datePanel;
+    private JDatePanel<T> datePanel;
 
-    /**
-     * Create a JDatePicker with a default calendar model.
-     */
     public JDatePicker() {
-        this(new JDatePanel());
     }
-
-    /**
-     * Create a JDatePicker with an initial value, with a UtilCalendarModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePicker(Calendar value) {
-        this(new JDatePanel(value));
-    }
-
-    /**
-     * Create a JDatePicker with an initial value, with a UtilDateModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePicker(java.util.Date value) {
-        this(new JDatePanel(value));
-    }
-
-    /**
-     * Create a JDatePicker with an initial value, with a SqlDateModel.
-     *
-     * @param value the initial value
-     */
-    public JDatePicker(java.sql.Date value) {
-        this(new JDatePanel(value));
-    }
-
-    /**
-     * Create a JDatePicker with a custom date model.
-     *
-     * @param model a custom date model
-     */
-    public JDatePicker(DateModel<?> model) {
-        this(new JDatePanel(model));
-    }
-
 
     /**
      * You are able to set the format of the date being displayed on the label.
@@ -114,7 +73,7 @@ public class JDatePicker extends JComponent implements DatePicker {
      *
      * @param datePanel The DatePanel to use
      */
-    private JDatePicker(JDatePanel datePanel) {
+    protected JDatePicker(JDatePanel<T> datePanel) {
         this.datePanel = datePanel;
 
         //Initialise Variables
@@ -129,7 +88,7 @@ public class JDatePicker extends JComponent implements DatePicker {
         //Create and Add Components
         //Add and Configure TextField
         formattedTextField = new JFormattedTextField(new DateComponentFormatter());
-        DateModel<?> model = datePanel.getModel();
+        DateModel<T> model = datePanel.getModel();
         setTextFieldValue(formattedTextField, model.getYear(), model.getMonth(), model.getDay(), model.isSelected());
         formattedTextField.setEditable(false);
         add(formattedTextField);
@@ -182,7 +141,7 @@ public class JDatePicker extends JComponent implements DatePicker {
         datePanel.removeActionListener(actionListener);
     }
 
-    public DateModel<?> getModel() {
+    public DateModel<T> getModel() {
         return datePanel.getModel();
     }
 

--- a/src/main/java/org/jdatepicker/JSqlDatePanel.java
+++ b/src/main/java/org/jdatepicker/JSqlDatePanel.java
@@ -25,37 +25,26 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.sql.Date;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JSqlDatePanel extends JDatePanel<Date>{
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JSqlDatePanel() {
+    }
+    
+    public JSqlDatePanel(Date value) {
+        this(new SqlDateModel(value));
     }
 
+    public JSqlDatePanel(DateModel<Date> model) {
+        super(model);
+    }
+    
 }

--- a/src/main/java/org/jdatepicker/JSqlDatePanel.java
+++ b/src/main/java/org/jdatepicker/JSqlDatePanel.java
@@ -37,6 +37,7 @@ public class JSqlDatePanel extends JDatePanel<Date>{
     private static final long serialVersionUID = 1L;
 
     public JSqlDatePanel() {
+        this(new SqlDateModel());
     }
     
     public JSqlDatePanel(Date value) {

--- a/src/main/java/org/jdatepicker/JSqlDatePicker.java
+++ b/src/main/java/org/jdatepicker/JSqlDatePicker.java
@@ -25,37 +25,23 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.sql.Date;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JSqlDatePicker extends JDatePicker<Date> {
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JSqlDatePicker() {
+        super(new JSqlDatePanel());
     }
-
+    
+    public JSqlDatePicker(Date value) {
+        super(new JSqlDatePanel(value));
+    }
+    
 }

--- a/src/main/java/org/jdatepicker/JUtilCalendarPanel.java
+++ b/src/main/java/org/jdatepicker/JUtilCalendarPanel.java
@@ -25,37 +25,26 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.util.Calendar;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JUtilCalendarPanel extends JDatePanel<Calendar> {
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JUtilCalendarPanel() {
     }
 
+    public JUtilCalendarPanel(Calendar value) {
+        this(new UtilCalendarModel(value));
+    }
+
+    public JUtilCalendarPanel(DateModel<Calendar> model) {
+        super(model);
+    }
+    
 }

--- a/src/main/java/org/jdatepicker/JUtilCalendarPicker.java
+++ b/src/main/java/org/jdatepicker/JUtilCalendarPicker.java
@@ -25,37 +25,23 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.util.Calendar;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JUtilCalendarPicker extends JDatePicker<java.util.Calendar> {
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JUtilCalendarPicker() {
+        super(new JUtilCalendarPanel());
     }
 
+    public JUtilCalendarPicker(Calendar value) {
+        super(new JUtilCalendarPanel(value));
+    }
+    
 }

--- a/src/main/java/org/jdatepicker/JUtilDatePanel.java
+++ b/src/main/java/org/jdatepicker/JUtilDatePanel.java
@@ -25,37 +25,26 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.util.Date;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JUtilDatePanel extends JDatePanel<Date> {
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JUtilDatePanel() {
     }
 
+    public JUtilDatePanel(Date value) {
+        this(new UtilDateModel(value));
+    }
+
+    public JUtilDatePanel(DateModel<Date> model) {
+        super(model);
+    }
+    
 }

--- a/src/main/java/org/jdatepicker/JUtilDatePanel.java
+++ b/src/main/java/org/jdatepicker/JUtilDatePanel.java
@@ -37,6 +37,7 @@ public class JUtilDatePanel extends JDatePanel<Date> {
     private static final long serialVersionUID = 1L;
 
     public JUtilDatePanel() {
+        this(new UtilDateModel());
     }
 
     public JUtilDatePanel(Date value) {

--- a/src/main/java/org/jdatepicker/JUtilDatePicker.java
+++ b/src/main/java/org/jdatepicker/JUtilDatePicker.java
@@ -25,37 +25,23 @@
  authors and should not be interpreted as representing official policies, either expressed
  or implied, of Juan Heyns.
  */
-package org.jdatepicker.issues;
+package org.jdatepicker;
 
-import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
+import java.util.Date;
 
-import javax.swing.*;
-import java.awt.*;
-import java.util.Locale;
-import org.jdatepicker.JUtilDatePicker;
+/**
+ *
+ * @author richter
+ */
+public class JUtilDatePicker extends JDatePicker<Date> {
+    private static final long serialVersionUID = 1L;
 
-public class Issue26 {
-
-    public static void main(String[] args) {
-        Locale.setDefault(new Locale("ar", "sa"));
-
-        JFrame testFrame = new JFrame();
-        testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        testFrame.setSize(500, 500);
-        JPanel jPanel = new JPanel();
-        DatePicker<?> picker = new JUtilDatePicker();
-        picker.setTextEditable(true);
-        picker.setShowYearButtons(true);
-        jPanel.add((JComponent) picker);
-
-        JPanel DatePanel = new JPanel();
-        DatePanel.setLayout(new BorderLayout());
-        DatePanel.add(jPanel, BorderLayout.WEST);
-        BorderLayout fb = new BorderLayout();
-        testFrame.setLayout(fb);
-        testFrame.getContentPane().add(DatePanel, BorderLayout.WEST);
-        testFrame.setVisible(true);
+    public JUtilDatePicker() {
+        super(new JUtilDatePanel());
     }
-
+    
+    public JUtilDatePicker(Date value) {
+        super(new JUtilDatePanel(value));
+    }
+    
 }

--- a/src/test/java/org/jdatepicker/TestJDatePanel.java
+++ b/src/test/java/org/jdatepicker/TestJDatePanel.java
@@ -33,7 +33,7 @@ public class TestJDatePanel {
 
     public static void main(String[] args) {
         JFrame testFrame = new JFrame();
-        DatePanel panel = new JDatePanel();
+        DatePanel panel = new JUtilDatePanel();
         panel.setShowYearButtons(true);
         testFrame.getContentPane().add((JComponent) panel);
         // TODO create a feature class to describe these types of variables

--- a/src/test/java/org/jdatepicker/TestJDatePicker.java
+++ b/src/test/java/org/jdatepicker/TestJDatePicker.java
@@ -41,7 +41,7 @@ public class TestJDatePicker {
         testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         testFrame.setSize(500, 500);
         JPanel jPanel = new JPanel();
-        DatePicker picker = new JDatePicker();
+        DatePicker picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
         jPanel.add((JComponent) picker);

--- a/src/test/java/org/jdatepicker/features/Feature1.java
+++ b/src/test/java/org/jdatepicker/features/Feature1.java
@@ -8,6 +8,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Simplest case for each one of the supported components.
@@ -30,11 +32,11 @@ public class Feature1 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel();
+        final JDatePanel<?> datePanel = new JUtilDatePanel();
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        final JDatePicker<?> datePicker = new JUtilDatePicker();
         panel.add(datePicker);
 
         // Add a button to print out date value

--- a/src/test/java/org/jdatepicker/features/Feature10.java
+++ b/src/test/java/org/jdatepicker/features/Feature10.java
@@ -7,6 +7,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Opening and closing the popup of JDatePicker.
@@ -36,7 +37,7 @@ public class Feature10 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        final JDatePicker datePicker = new JUtilDatePicker();
 //        datePicker.setDoubleClickAction(true);
         panel.add(datePicker);
 

--- a/src/test/java/org/jdatepicker/features/Feature2.java
+++ b/src/test/java/org/jdatepicker/features/Feature2.java
@@ -7,6 +7,12 @@ import javax.swing.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Calendar;
+import org.jdatepicker.JSqlDatePanel;
+import org.jdatepicker.JSqlDatePicker;
+import org.jdatepicker.JUtilCalendarPanel;
+import org.jdatepicker.JUtilCalendarPicker;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Construct the components specifying some initial data in the constructor.
@@ -31,7 +37,7 @@ public class Feature2 {
         c.set(Calendar.YEAR, 1980);
         c.set(Calendar.MONTH, 4);
         c.set(Calendar.DATE, 1);
-        final JDatePanel datePanel1 = new JDatePanel(c);
+        final JDatePanel<?> datePanel1 = new JUtilCalendarPanel(c);
         datePanel1.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -41,7 +47,7 @@ public class Feature2 {
 
         c.set(Calendar.MONTH, 5);
         c.set(Calendar.DATE, 6);
-        final JDatePanel datePanel2 = new JDatePanel(new java.util.Date(c.getTimeInMillis()));
+        final JDatePanel<?> datePanel2 = new JUtilDatePanel(new java.util.Date(c.getTimeInMillis()));
         datePanel2.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -52,7 +58,7 @@ public class Feature2 {
         c.set(Calendar.YEAR, 2014);
         c.set(Calendar.MONTH, 5);
         c.set(Calendar.DATE, 13);
-        final JDatePanel datePanel3 = new JDatePanel(new java.sql.Date(c.getTimeInMillis()));
+        final JDatePanel<?> datePanel3 = new JSqlDatePanel(new java.sql.Date(c.getTimeInMillis()));
         datePanel3.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -60,7 +66,7 @@ public class Feature2 {
         });
         panel.add(datePanel3);
 
-        final JDatePanel datePanel4 = new JDatePanel();
+        final JDatePanel<?> datePanel4 = new JSqlDatePanel();
         datePanel4.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -72,7 +78,7 @@ public class Feature2 {
         c.set(Calendar.YEAR, 1980);
         c.set(Calendar.MONTH, 4);
         c.set(Calendar.DATE, 1);
-        final JDatePicker datePicker1 = new JDatePicker(c);
+        final JDatePicker datePicker1 = new JUtilCalendarPicker(c);
         datePicker1.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -82,7 +88,7 @@ public class Feature2 {
 
         c.set(Calendar.MONTH, 5);
         c.set(Calendar.DATE, 6);
-        final JDatePicker datePicker2= new JDatePicker(new java.util.Date(c.getTimeInMillis()));
+        final JDatePicker datePicker2 = new JUtilDatePicker(new java.util.Date(c.getTimeInMillis()));
         datePicker2.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -93,7 +99,7 @@ public class Feature2 {
         c.set(Calendar.YEAR, 2014);
         c.set(Calendar.MONTH, 5);
         c.set(Calendar.DATE, 13);
-        final JDatePicker datePicker3 = new JDatePicker(new java.sql.Date(c.getTimeInMillis()));
+        final JDatePicker datePicker3 = new JSqlDatePicker(new java.sql.Date(c.getTimeInMillis()));
         datePicker3.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));
@@ -101,7 +107,7 @@ public class Feature2 {
         });
         panel.add(datePicker3);
 
-        final JDatePicker datePicker4 = new JDatePicker();
+        final JDatePicker datePicker4 = new JUtilDatePicker();
         datePicker4.getModel().addPropertyChangeListener(new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent e) {
                 System.out.println(String.format("%s: %s -> %s", e.getPropertyName(), e.getOldValue(), e.getNewValue()));

--- a/src/test/java/org/jdatepicker/features/Feature3.java
+++ b/src/test/java/org/jdatepicker/features/Feature3.java
@@ -10,6 +10,8 @@ import javax.swing.event.ChangeListener;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.jdatepicker.DateModel;
+import org.jdatepicker.JUtilDatePanel;
 
 /**
  * Construct components with a custom date model.
@@ -30,7 +32,7 @@ public class Feature3 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePanel
-        final JDatePanel datePanel1 = new JDatePanel(new DemoDateModel("1980-05-01"));
+        final JDatePanel datePanel1 = new JStringDatePanel(new DemoDateModel("1980-05-01"));
         datePanel1.getModel().addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
                 DemoDateModel source = (DemoDateModel) e.getSource();
@@ -39,7 +41,7 @@ public class Feature3 {
         });
         panel.add(datePanel1);
 
-        final JDatePanel datePanel2 = new JDatePanel(new DemoDateModel(null));
+        final JDatePanel datePanel2 = new JStringDatePanel(new DemoDateModel(null));
         datePanel2.getModel().addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
                 DemoDateModel source = (DemoDateModel) e.getSource();
@@ -49,7 +51,7 @@ public class Feature3 {
         panel.add(datePanel2);
 
         // Create the JDatePicker
-        final JDatePicker datePicker1 = new JDatePicker(new DemoDateModel("1980-06-06"));
+        final JDatePicker datePicker1 = new JStringDatePicker(new DemoDateModel("1980-06-06"));
         datePicker1.getModel().addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
                 DemoDateModel source = (DemoDateModel) e.getSource();
@@ -58,7 +60,7 @@ public class Feature3 {
         });
         panel.add(datePicker1);
 
-        final JDatePicker datePicker2 = new JDatePicker(new DemoDateModel(null));
+        final JDatePicker datePicker2 = new JStringDatePicker(new DemoDateModel(null));
         datePicker2.getModel().addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
                 DemoDateModel source = (DemoDateModel) e.getSource();
@@ -71,6 +73,21 @@ public class Feature3 {
         frame.setVisible(true);
     }
 
+    public static class JStringDatePicker extends JDatePicker<String> {
+        private static final long serialVersionUID = 1L;
+
+        public JStringDatePicker(DateModel<String> model) {
+            super(new JStringDatePanel(model));
+        }
+    }
+
+    public static class JStringDatePanel extends JDatePanel<String> {
+
+        public JStringDatePanel(DateModel<String> model) {
+            super(model);
+        }
+    }
+            
     public static class DemoDateModel extends AbstractDateModel<String> {
 
         private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/src/test/java/org/jdatepicker/features/Feature4.java
+++ b/src/test/java/org/jdatepicker/features/Feature4.java
@@ -4,6 +4,8 @@ import org.jdatepicker.JDatePanel;
 import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Change the LnF for the component.
@@ -27,11 +29,11 @@ public class Feature4 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel();
+        JDatePanel<?> datePanel = new JUtilDatePanel();
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        JDatePicker<?> datePicker = new JUtilDatePicker();
         panel.add(datePicker);
 
         // Make the frame visible

--- a/src/test/java/org/jdatepicker/features/Feature5.java
+++ b/src/test/java/org/jdatepicker/features/Feature5.java
@@ -5,6 +5,8 @@ import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
 import java.util.Locale;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Change the locale for the widget.
@@ -48,11 +50,11 @@ public class Feature5 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel();
+        final JDatePanel<?> datePanel = new JUtilDatePanel();
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        final JDatePicker<?> datePicker = new JUtilDatePicker();
         panel.add(datePicker);
 
         // Make the frame visible

--- a/src/test/java/org/jdatepicker/features/Feature6.java
+++ b/src/test/java/org/jdatepicker/features/Feature6.java
@@ -5,6 +5,8 @@ import org.jdatepicker.JDatePanel;
 import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * In some cases a locale may not be supported, in which case you will want to change the default texts for a widget.
@@ -52,11 +54,11 @@ public class Feature6 {
         defaults.setText(ComponentTextDefaults.Key.SAT, "Sa");
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel();
+        final JDatePanel<?> datePanel = new JUtilDatePanel();
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        final JDatePicker<?> datePicker = new JUtilDatePicker();
         panel.add(datePicker);
 
         // Make the frame visible

--- a/src/test/java/org/jdatepicker/features/Feature7.java
+++ b/src/test/java/org/jdatepicker/features/Feature7.java
@@ -9,6 +9,9 @@ import org.jdatepicker.constraints.DateSelectionConstraint;
 import javax.swing.*;
 import java.awt.*;
 import java.util.Calendar;
+import org.jdatepicker.JUtilCalendarPanel;
+import org.jdatepicker.JUtilCalendarPicker;
+import org.jdatepicker.JUtilDatePanel;
 
 /**
  * Colour theme may be changed to match application style or the platform colours.
@@ -61,7 +64,7 @@ public class Feature7 {
         defaults.setColor(ComponentColorDefaults.Key.POPUP_BORDER, Color.WHITE);
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel(Calendar.getInstance());
+        final JDatePanel<?> datePanel = new JUtilCalendarPanel(Calendar.getInstance());
         datePanel.addDateSelectionConstraint(new DateSelectionConstraint() {
             public boolean isValidSelection(DateModel<?> model) {
                 Calendar c = Calendar.getInstance();
@@ -74,7 +77,7 @@ public class Feature7 {
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker(Calendar.getInstance());
+        final JDatePicker<?> datePicker = new JUtilCalendarPicker(Calendar.getInstance());
         panel.add(datePicker);
 
         // Make the frame visible

--- a/src/test/java/org/jdatepicker/features/Feature8.java
+++ b/src/test/java/org/jdatepicker/features/Feature8.java
@@ -7,6 +7,8 @@ import org.jdatepicker.JDatePicker;
 import javax.swing.*;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.jdatepicker.JUtilCalendarPanel;
+import org.jdatepicker.JUtilCalendarPicker;
 
 /**
  * Change the date display formats.
@@ -38,11 +40,11 @@ public class Feature8 {
         defaults.setFormat(ComponentFormatDefaults.Key.MONTH_SELECTOR, new SimpleDateFormat("MMM"));
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel(Calendar.getInstance());
+        final JDatePanel<?> datePanel = new JUtilCalendarPanel(Calendar.getInstance());
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker(Calendar.getInstance());
+        final JDatePicker<?> datePicker = new JUtilCalendarPicker(Calendar.getInstance());
         datePicker.setTextEditable(true);
         panel.add(datePicker);
 

--- a/src/test/java/org/jdatepicker/features/Feature9.java
+++ b/src/test/java/org/jdatepicker/features/Feature9.java
@@ -8,6 +8,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Disable a the widget.
@@ -28,12 +30,12 @@ public class Feature9 {
         frame.getContentPane().add(panel);
 
         // Create the JDatePanel
-        final JDatePanel datePanel = new JDatePanel();
+        final JDatePanel<?> datePanel = new JUtilDatePanel();
         datePanel.setEnabled(false);
         panel.add(datePanel);
 
         // Create the JDatePicker
-        final JDatePicker datePicker = new JDatePicker();
+        final JDatePicker<?> datePicker = new JUtilDatePicker();
         datePicker.setEnabled(false);
         panel.add(datePicker);
 

--- a/src/test/java/org/jdatepicker/issues/Issue18.java
+++ b/src/test/java/org/jdatepicker/issues/Issue18.java
@@ -3,6 +3,7 @@ package org.jdatepicker.issues;
 import org.jdatepicker.JDatePanel;
 
 import javax.swing.*;
+import org.jdatepicker.JUtilDatePanel;
 
 public class Issue18 {
 
@@ -13,7 +14,7 @@ public class Issue18 {
         frame.setSize(200, 200);
 
         // Create the JDatePanel and add it to the main content pane, resizing the window will resize the panel
-        final JDatePanel datePanel = new JDatePanel();
+        final JDatePanel datePanel = new JUtilDatePanel();
         frame.getContentPane().add(datePanel);
 
         // Make the frame visible

--- a/src/test/java/org/jdatepicker/issues/Issue19.java
+++ b/src/test/java/org/jdatepicker/issues/Issue19.java
@@ -6,6 +6,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import org.jdatepicker.JUtilDatePicker;
 
 public class Issue19 extends JFrame {
     private static final long serialVersionUID = 1L;
@@ -21,7 +22,7 @@ public class Issue19 extends JFrame {
 
         // create components
         final Container cont = getContentPane();
-        final JDatePicker picker = new JDatePicker();
+        final JDatePicker<?> picker = new JUtilDatePicker();
         final JButton right = new JButton("show / hide");
 
         // add button action

--- a/src/test/java/org/jdatepicker/issues/Issue20.java
+++ b/src/test/java/org/jdatepicker/issues/Issue20.java
@@ -29,10 +29,10 @@ package org.jdatepicker.issues;
 
 import org.jdatepicker.ComponentTextDefaults;
 import org.jdatepicker.DatePicker;
-import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
 import java.awt.*;
+import org.jdatepicker.JUtilDatePicker;
 
 
 public class Issue20 {
@@ -53,7 +53,7 @@ public class Issue20 {
         defaults.setText(ComponentTextDefaults.Key.YEAR, "Raey");
         defaults.setText(ComponentTextDefaults.Key.CLEAR, "Raelc");
 
-        DatePicker picker = new JDatePicker();
+        DatePicker<?> picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
 //        picker.getModel().setSelected(true);

--- a/src/test/java/org/jdatepicker/issues/Issue31.java
+++ b/src/test/java/org/jdatepicker/issues/Issue31.java
@@ -36,6 +36,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import org.jdatepicker.JUtilDatePicker;
 
 public class Issue31 {
 
@@ -44,7 +45,7 @@ public class Issue31 {
         testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         testFrame.setSize(500, 500);
         JPanel jPanel = new JPanel();
-        DatePicker picker = new JDatePicker();
+        DatePicker<?> picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
         picker.getModel().addPropertyChangeListener(

--- a/src/test/java/org/jdatepicker/issues/Issue4.java
+++ b/src/test/java/org/jdatepicker/issues/Issue4.java
@@ -34,6 +34,7 @@ import org.jdatepicker.constraints.RangeConstraint;
 import javax.swing.*;
 import java.awt.*;
 import java.util.Calendar;
+import org.jdatepicker.JUtilDatePicker;
 
 public class Issue4 {
 
@@ -42,7 +43,7 @@ public class Issue4 {
         testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         testFrame.setSize(500, 500);
         JPanel jPanel = new JPanel();
-        DatePicker picker = new JDatePicker();
+        DatePicker<?> picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
         picker.addDateSelectionConstraint(new RangeConstraint(null, Calendar

--- a/src/test/java/org/jdatepicker/issues/Issue46.java
+++ b/src/test/java/org/jdatepicker/issues/Issue46.java
@@ -9,6 +9,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import org.jdatepicker.JUtilDatePanel;
+import org.jdatepicker.JUtilDatePicker;
 
 public class Issue46 {
 
@@ -17,11 +19,11 @@ public class Issue46 {
         testFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         testFrame.setSize(500, 500);
 
-        final DatePicker picker = new JDatePicker();
+        final DatePicker<?> picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
 
-        final DatePanel panel = new JDatePanel();
+        final DatePanel<?> panel = new JUtilDatePanel();
         panel.setShowYearButtons(true);
 
         picker.getModel().setYear(2010);

--- a/src/test/java/org/jdatepicker/issues/IssueXX.java
+++ b/src/test/java/org/jdatepicker/issues/IssueXX.java
@@ -5,6 +5,7 @@ import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
 import java.awt.*;
+import org.jdatepicker.JUtilDatePicker;
 
 /**
  * Created by jheyns on 2014/10/07.
@@ -17,7 +18,7 @@ public class IssueXX {
         testFrame.setSize(500, 500);
         JPanel jPanel = new JPanel();
 
-        DatePicker picker = new JDatePicker();
+        DatePicker<?> picker = new JUtilDatePicker();
         picker.setTextEditable(true);
         picker.setShowYearButtons(true);
         jPanel.add((JComponent) picker);


### PR DESCRIPTION
…onstructor in favour of typesafe subclasses (there's no sense in managing the type of model value in a class property in Java if it can be managed in the type); the feature to create model from a value passed to a constructor is consequently no longer supported and belongs into a factory class anyway (which might be reinserted)
