### PR TITLE
Fixed off by one error for the day of week on the calendar

### DIFF
--- a/src/main/java/org/jdatepicker/ComponentTextDefaults.java
+++ b/src/main/java/org/jdatepicker/ComponentTextDefaults.java
@@ -157,7 +157,7 @@ public final class ComponentTextDefaults {
         }
         if (text == null && "dow".equals(key.getKind())) {
             Calendar c = Calendar.getInstance();
-            c.set(Calendar.DAY_OF_WEEK, key.getIndex());
+            c.set(Calendar.DAY_OF_WEEK, key.getIndex() + 1);        // In a calendar, the day of the week is ONE INDEXED, while the keys we're using are ZERO INDEXED
             ComponentFormatDefaults defaults = ComponentFormatDefaults.getInstance();
             DateFormat dowFormat = defaults.getFormat(ComponentFormatDefaults.Key.DOW_HEADER);
             text = dowFormat.format(c.getTime());


### PR DESCRIPTION
When I first used JDatePicker all of the day names were off by one (for example the leftmost column, with all of the Sundays, was labeled "FRI"). It's probably just easier to explain with a screenshot— As you may remember, Nov 1 was a Sunday
![screen shot 2015-11-03 at 11 10 30 pm](https://cloud.githubusercontent.com/assets/3222012/10931837/1e94807e-8280-11e5-97fc-ba78cceefe4b.png)
The lookup table in JDatePicker is 0 indexed (e.g. Sunday is 0, Monday 1, etc. However, JDatePicker formats the days of the week, it uses a Calendar's DAY_OF_WEEK, which is 1 indexed (Sunday is 1, Monday is 2, etc..) This fixes that issue (although maybe it'd be better to integrate better with Java's builtin localization like Calendar.getFirstDayOfWeek())

TestJDatePanel after the fix has been applied:
![screen shot 2015-11-03 at 11 10 18 pm](https://cloud.githubusercontent.com/assets/3222012/10931839/227ceaa0-8280-11e5-91ef-ea5b91235f6a.png)
