### PR TITLE
added baseline behaviour based on formattedTextField to JDatePicker (…

### DIFF
--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -407,4 +407,13 @@ public class JDatePicker extends JComponent implements DatePicker {
 
     }
 
+    @Override
+    public int getBaseline(int width, int height) {
+        return formattedTextField.getBaseline(width, height);
+    }
+
+    @Override
+    public BaselineResizeBehavior getBaselineResizeBehavior() {
+        return formattedTextField.getBaselineResizeBehavior();
+    }
 }


### PR DESCRIPTION
…changed minimum version of Java to 6 in animal-sniffer-maven-plugin in order to allow overriding getBaseline)
