### PR TITLE
Contributed feature 11: DatePanel.setTodayMarkingBorder(Color color)

### DIFF
--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -27,6 +27,8 @@
  */
 package org.jdatepicker;
 
+import java.awt.Color;
+
 public interface DatePanel extends DateComponent {
 
     /**
@@ -56,5 +58,12 @@ public interface DatePanel extends DateComponent {
      * @return Is a double click required to fire a ActionEvent.
      */
     boolean isDoubleClickAction();
+    
+    /**
+     * @param color sets the border around the number of today with
+     * the specified color. Disables red color for number of today.
+     * Default is no border.
+     */
+    public void setTodayMarkingBorder (Color color);
 
 }

--- a/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/src/main/java/org/jdatepicker/JDatePanel.java
@@ -42,6 +42,8 @@ import java.awt.*;
 import java.awt.event.*;
 import java.text.DateFormat;
 import java.util.*;
+import javax.swing.border.Border;
+import org.jdatepicker.ComponentColorDefaults.Key;
 
 /**
  * Created on 26 Mar 2004
@@ -72,6 +74,8 @@ public class JDatePanel extends JComponent implements DatePanel {
     private InternalCalendarModel internalModel;
     private InternalController internalController;
     private InternalView internalView;
+    
+    private Border todayMarkingBorder;
 
     /**
      * Creates a JDatePanel with a default calendar model.
@@ -178,6 +182,21 @@ public class JDatePanel extends JComponent implements DatePanel {
      */
     public boolean isShowYearButtons() {
         return this.showYearButtons;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jdatepicker.DatePanel#setTodayMarkingBorder(color)
+     */
+    public void setTodayMarkingBorder (Color color){
+        this.todayMarkingBorder = BorderFactory.createLineBorder(color, 2);
+
+        ComponentColorDefaults colorDefaults = ComponentColorDefaults.getInstance();
+        Color everyDayColor = colorDefaults
+                .getColor(Key.FG_GRID_THIS_MONTH);
+        Color everyDaySelectedColor = colorDefaults
+                .getColor(Key.FG_GRID_SELECTED);
+        colorDefaults.setColor(Key.FG_GRID_TODAY, everyDayColor);
+        colorDefaults.setColor(Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
     }
 
     /* (non-Javadoc)
@@ -790,6 +809,10 @@ public class JDatePanel extends JComponent implements DatePanel {
                         && todayCal.get(Calendar.MONTH) == internalModel.getModel().getMonth()
                         && todayCal.get(Calendar.YEAR) == internalModel.getModel().getYear()) {
                     label.setForeground(getColors().getColor(ComponentColorDefaults.Key.FG_GRID_TODAY));
+                    
+                    //set border (null allowed):
+                    label.setBorder(todayMarkingBorder);
+                    
                     //Selected
                     if (internalModel.getModel().isSelected() && selectedCal.get(Calendar.DATE) == cellDayValue) {
                         label.setForeground(getColors().getColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED));

--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -273,6 +273,10 @@ public class JDatePicker extends JComponent implements DatePicker {
         datePanel.setShowYearButtons(showYearButtons);
     }
 
+    public void setTodayMarkingBorder (Color color){
+        datePanel.setTodayMarkingBorder(color);
+    }
+    
     private void setTextFieldValue(JFormattedTextField textField, int year, int month, int day, boolean isSelected) {
         if (!isSelected) {
             textField.setValue(null);

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -1,0 +1,39 @@
+package org.jdatepicker.features;
+
+import java.awt.Color;
+import java.awt.Component;
+import org.jdatepicker.JDatePicker;
+
+import javax.swing.*;
+
+/**
+ * a. Add a red border that is marking today.
+ * 
+ */
+public class Feature11 {
+
+    public static void main(final String[] args) {
+        // Create a frame
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setSize(550, 300);
+
+        // Create a flow layout panel
+        final JPanel jPanel = new JPanel();
+        frame.getContentPane().add(jPanel);
+
+        // Create the JDatePicker
+        final JDatePicker jDatePicker = new JDatePicker();
+        
+        //Set a red border marking today for JDatePicker
+        jDatePicker.setTodayMarkingBorder(Color.RED);
+        
+        // add the internal DatePanel to the layout panel of the frame
+        jPanel.add((Component)jDatePicker.getJDateInstantPanel());
+
+        // Make the frame visible
+        frame.setVisible(true);
+
+    }
+
+}


### PR DESCRIPTION
Hi Juan!
In many countries, a red number indicates a celebration day or a Sunday.
That's why I had the idea of an alternative marking for today:
this new feature(11) puts a border around the number of today with a
a specified color. It disables the red color for the number of today.
What do you think about this?
If you like what you see I could contribute a second version. This version
is modifying ComponentColorDefaults and has a different setter:
setShowTodayBorder(boolean showTodayBorder).
Cheers
Ralf