### PR TITLE
Contributing Feature11: today marking border

### DIFF
--- a/src/main/java/org/jdatepicker/ComponentColorDefaults.java
+++ b/src/main/java/org/jdatepicker/ComponentColorDefaults.java
@@ -104,7 +104,8 @@ public final class ComponentColorDefaults {
     }
 
     public void setColor(Key key, Color color) {
-        if(colors.get(key).equals(color)) customColors.put(key, color);
+        //add only colors different from default
+        if(!colors.get(key).equals(color)) customColors.put(key, color);
     }
 
     public void setToDefault(Key key) {

--- a/src/main/java/org/jdatepicker/ComponentColorDefaults.java
+++ b/src/main/java/org/jdatepicker/ComponentColorDefaults.java
@@ -56,16 +56,19 @@ public final class ComponentColorDefaults {
         BG_GRID_SELECTED,
         FG_GRID_TODAY_SELECTED,
         BG_GRID_TODAY_SELECTED,
+        FG_GRID_TODAY_BORDER,
         FG_TODAY_SELECTOR_ENABLED,
         FG_TODAY_SELECTOR_DISABLED,
         BG_TODAY_SELECTOR,
         POPUP_BORDER;
     }
 
-    private Map<Key, Color> colors;
+    private final Map<Key, Color> colors;
+    private final Map<Key, Color> customColors;
 
     private ComponentColorDefaults() {
-        colors = new HashMap<Key, Color>();
+        colors = new HashMap<>();
+        customColors = new HashMap<>();
 
         colors.put(Key.FG_MONTH_SELECTOR, SystemColor.activeCaptionText);
         colors.put(Key.BG_MONTH_SELECTOR, SystemColor.activeCaption);
@@ -88,16 +91,24 @@ public final class ComponentColorDefaults {
         colors.put(Key.FG_TODAY_SELECTOR_ENABLED, Color.BLACK);
         colors.put(Key.FG_TODAY_SELECTOR_DISABLED, Color.LIGHT_GRAY);
         colors.put(Key.BG_TODAY_SELECTOR, Color.WHITE);
+        
+        colors.put(Key.FG_GRID_TODAY_BORDER, Color.RED);
 
         colors.put(Key.POPUP_BORDER, Color.BLACK);
     }
 
     public Color getColor(Key key) {
+        Color color = customColors.get(key);
+        if(color!=null) return color;
         return colors.get(key);
     }
 
     public void setColor(Key key, Color color) {
-        colors.put(key, color);
+        if(colors.get(key).equals(color)) customColors.put(key, color);
+    }
+
+    public void setToDefault(Key key) {
+        customColors.remove(key);
     }
 
 }

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -94,6 +94,5 @@ public abstract class DatePanel extends JComponent implements DateComponent {
             colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY);
             colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED);
         }
-}
-
+    }
 }

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -27,6 +27,8 @@
  */
 package org.jdatepicker;
 
+import java.awt.Color;
+
 public interface DatePanel extends DateComponent {
 
     /**
@@ -56,5 +58,12 @@ public interface DatePanel extends DateComponent {
      * @return Is a double click required to fire a ActionEvent.
      */
     boolean isDoubleClickAction();
+    
+    /**
+     * @param color sets the border around the number of today with
+     * the specified color. Disables red color for number of today.
+     * Default is no border.
+     */
+    public void setTodayMarkingBorder (Color color);
 
 }

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -27,21 +27,25 @@
  */
 package org.jdatepicker;
 
-public interface DatePanel extends DateComponent {
+import java.awt.Color;
+import javax.swing.JComponent;
+
+public abstract class DatePanel extends JComponent implements DateComponent {
+    private static boolean showTodayBorder;
 
     /**
      * Sets the visibilty of the Year navigation buttons. Defaults to false.
      *
      * @param showYearButtons show the button?
      */
-    void setShowYearButtons(boolean showYearButtons);
+    public abstract void setShowYearButtons(boolean showYearButtons);
 
     /**
      * Is the year navigation buttons active.
      *
      * @return visiblity of the year
      */
-    boolean isShowYearButtons();
+    public abstract boolean isShowYearButtons();
 
     /**
      * This changes the behaviour of the control to require a double click on
@@ -50,12 +54,12 @@ public interface DatePanel extends DateComponent {
      *
      * @param doubleClickAction use double clicks?
      */
-    void setDoubleClickAction(boolean doubleClickAction);
+    public abstract void setDoubleClickAction(boolean doubleClickAction);
 
     /**
      * @return Is a double click required to fire a ActionEvent.
      */
-    boolean isDoubleClickAction();
+    public abstract boolean isDoubleClickAction();
     
     /**
      * Sets the visability of a red border that marks the number of 
@@ -63,11 +67,33 @@ public interface DatePanel extends DateComponent {
      * 
      * @param showTodayBorder show the border?
      */
-    void setStaticTodayBorder (boolean showTodayBorder);
+    public static final void setStaticTodayBorder(boolean showTodayBorder){
+        DatePanel.showTodayBorder = showTodayBorder;
+        setTodayNumberColorSchema(showTodayBorder);
+    }
     
     /**
      * @return is a border shown to mark today.
      */
-    boolean isShowTodayBorder ();
+    public static final boolean isShowTodayBorder(){
+        return DatePanel.showTodayBorder;
+    }
+    
+    private static void setTodayNumberColorSchema(boolean hasBorder){
+            ComponentColorDefaults colorSchema = ComponentColorDefaults.getInstance();
+            //set today's number color statically, depending on visibility of a surrounding border
+            if (hasBorder) {
+                Color everyDayColor = colorSchema
+                        .getColor(ComponentColorDefaults.Key.FG_GRID_THIS_MONTH);
+                Color everyDaySelectedColor = colorSchema
+                        .getColor(ComponentColorDefaults.Key.FG_GRID_SELECTED);
+
+                colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, everyDayColor);
+                colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
+            } else {
+                colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY);
+                colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED);
+            }
+    }
 
 }

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -27,8 +27,6 @@
  */
 package org.jdatepicker;
 
-import java.awt.Color;
-
 public interface DatePanel extends DateComponent {
 
     /**
@@ -60,10 +58,16 @@ public interface DatePanel extends DateComponent {
     boolean isDoubleClickAction();
     
     /**
-     * @param color sets the border around the number of today with
-     * the specified color. Disables red color for number of today.
-     * Default is no border.
+     * Sets the visability of a red border that marks the number of 
+     * today instead of a colored number. Defaults to false.
+     * 
+     * @param showTodayBorder show the border?
      */
-    public void setTodayMarkingBorder (Color color);
+    void setStaticTodayBorder (boolean showTodayBorder);
+    
+    /**
+     * @return is a border shown to mark today.
+     */
+    boolean isShowTodayBorder ();
 
 }

--- a/src/main/java/org/jdatepicker/DatePanel.java
+++ b/src/main/java/org/jdatepicker/DatePanel.java
@@ -67,7 +67,7 @@ public abstract class DatePanel extends JComponent implements DateComponent {
      * 
      * @param showTodayBorder show the border?
      */
-    public static final void setStaticTodayBorder(boolean showTodayBorder){
+    public static final void setTodayBorder(boolean showTodayBorder){
         DatePanel.showTodayBorder = showTodayBorder;
         setTodayNumberColorSchema(showTodayBorder);
     }
@@ -80,20 +80,20 @@ public abstract class DatePanel extends JComponent implements DateComponent {
     }
     
     private static void setTodayNumberColorSchema(boolean hasBorder){
-            ComponentColorDefaults colorSchema = ComponentColorDefaults.getInstance();
-            //set today's number color statically, depending on visibility of a surrounding border
-            if (hasBorder) {
-                Color everyDayColor = colorSchema
-                        .getColor(ComponentColorDefaults.Key.FG_GRID_THIS_MONTH);
-                Color everyDaySelectedColor = colorSchema
-                        .getColor(ComponentColorDefaults.Key.FG_GRID_SELECTED);
+        ComponentColorDefaults colorSchema = ComponentColorDefaults.getInstance();
+        //set today's number color statically, depending on visibility of a surrounding border
+        if (hasBorder) {
+            Color everyDayColor = colorSchema
+                    .getColor(ComponentColorDefaults.Key.FG_GRID_THIS_MONTH);
+            Color everyDaySelectedColor = colorSchema
+                    .getColor(ComponentColorDefaults.Key.FG_GRID_SELECTED);
 
-                colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, everyDayColor);
-                colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
-            } else {
-                colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY);
-                colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED);
-            }
-    }
+            colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, everyDayColor);
+            colorSchema.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
+        } else {
+            colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY);
+            colorSchema.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED);
+        }
+}
 
 }

--- a/src/main/java/org/jdatepicker/DatePicker.java
+++ b/src/main/java/org/jdatepicker/DatePicker.java
@@ -29,42 +29,42 @@ package org.jdatepicker;
 
 import javax.swing.*;
 
-public interface DatePicker extends DatePanel {
+public abstract class DatePicker extends DatePanel {
 
     /**
      * Is the text component editable or not. Defaults to false.
      *
      * @param editable should the textfield be editable?
      */
-    void setTextEditable(boolean editable);
+    public abstract void setTextEditable(boolean editable);
 
     /**
      * @return Is the text component editable?
      */
-    boolean isTextEditable();
+    public abstract boolean isTextEditable();
 
     /**
      * Sets the button to be focusable. Defaults to true.
      *
      * @param focusable should the button be focusable?
      */
-    void setButtonFocusable(boolean focusable);
+    public abstract void setButtonFocusable(boolean focusable);
 
     /**
      * @return Is the button focusable?
      */
-    boolean getButtonFocusable();
+    public abstract boolean getButtonFocusable();
 
     /**
      * @return Columns the size of the underlying textfield
      */
-    int getTextfieldColumns();
+    public abstract int getTextfieldColumns();
 
     /**
      * Sets the size of the underlying textfield in columns
      *
      * @param columns {@link JTextField#setColumns(int)}
      */
-    void setTextfieldColumns(int columns);
+    public abstract void setTextfieldColumns(int columns);
 
 }

--- a/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/src/main/java/org/jdatepicker/JDatePanel.java
@@ -59,7 +59,7 @@ import java.util.*;
  * @author JC Oosthuizen
  * @author Yue Huang
  */
-public class JDatePanel extends JComponent implements DatePanel {
+public class JDatePanel extends DatePanel {
 
     private static final long serialVersionUID = -2299249311312882915L;
 
@@ -67,7 +67,6 @@ public class JDatePanel extends JComponent implements DatePanel {
     private Set<DateSelectionConstraint> dateConstraints;
 
     private boolean showYearButtons;
-    private static boolean showTodayBorder;
     private boolean doubleClickAction;
 
     private InternalCalendarModel internalModel;
@@ -179,21 +178,6 @@ public class JDatePanel extends JComponent implements DatePanel {
      */
     public boolean isShowYearButtons() {
         return this.showYearButtons;
-    }
-
-    /* (non-Javadoc)
-     * @see org.jdatepicker.JDatePanel#setStaticTodayBorder(boolean)
-     */
-    public void setStaticTodayBorder(boolean showTodayBorder){
-        JDatePanel.showTodayBorder = showTodayBorder;
-        internalView.updateShowTodayBorder();
-    }
-
-    /* (non-Javadoc)
-     * @see org.jdatepicker.JDatePanel#isShowTodayBorder()
-     */
-    public boolean isShowTodayBorder(){
-        return JDatePanel.showTodayBorder;
     }
 
     /* (non-Javadoc)
@@ -315,23 +299,6 @@ public class JDatePanel extends JComponent implements DatePanel {
             } else {
                 getNextButtonPanel().remove(getNextYearButton());
                 getPreviousButtonPanel().remove(getPreviousYearButton());
-            }
-        }
-
-        private void updateShowTodayBorder() {
-            ComponentColorDefaults colorDefaults = ComponentColorDefaults.getInstance();
-            //set today's number color statically, depending on visibility of a surrounding border
-            if (JDatePanel.showTodayBorder) {
-                Color everyDayColor = getColors()
-                        .getColor(ComponentColorDefaults.Key.FG_GRID_THIS_MONTH);
-                Color everyDaySelectedColor = getColors()
-                        .getColor(ComponentColorDefaults.Key.FG_GRID_SELECTED);
-
-                colorDefaults.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, everyDayColor);
-                colorDefaults.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
-            } else {
-                colorDefaults.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY);
-                colorDefaults.setToDefault(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED);
             }
         }
 
@@ -824,7 +791,7 @@ public class JDatePanel extends JComponent implements DatePanel {
                         && todayCal.get(Calendar.YEAR) == internalModel.getModel().getYear()) {
                     
                     //Mark today with a border or with a colored number
-                    if(JDatePanel.showTodayBorder&&super.isEnabled()){
+                    if(DatePanel.isShowTodayBorder()&&super.isEnabled()){
                         Color borderColor = getColors()
                                 .getColor(ComponentColorDefaults.Key.FG_GRID_TODAY_BORDER);
 

--- a/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/src/main/java/org/jdatepicker/JDatePanel.java
@@ -42,6 +42,8 @@ import java.awt.*;
 import java.awt.event.*;
 import java.text.DateFormat;
 import java.util.*;
+import javax.swing.border.Border;
+import org.jdatepicker.ComponentColorDefaults.Key;
 
 /**
  * Created on 26 Mar 2004
@@ -72,6 +74,8 @@ public class JDatePanel extends JComponent implements DatePanel {
     private InternalCalendarModel internalModel;
     private InternalController internalController;
     private InternalView internalView;
+    
+    private Border todayMarkingBorder;
 
     /**
      * Creates a JDatePanel with a default calendar model.
@@ -178,6 +182,21 @@ public class JDatePanel extends JComponent implements DatePanel {
      */
     public boolean isShowYearButtons() {
         return this.showYearButtons;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jdatepicker.DatePanel#setTodayMarkingBorder(color)
+     */
+    public void setTodayMarkingBorder (Color color){
+        this.todayMarkingBorder = BorderFactory.createLineBorder(color, 2);
+
+        ComponentColorDefaults colorDefaults = ComponentColorDefaults.getInstance();
+        Color everyDayColor = colorDefaults
+                .getColor(Key.FG_GRID_THIS_MONTH);
+        Color everyDaySelectedColor = colorDefaults
+                .getColor(Key.FG_GRID_SELECTED);
+        colorDefaults.setColor(Key.FG_GRID_TODAY, everyDayColor);
+        colorDefaults.setColor(Key.FG_GRID_TODAY_SELECTED, everyDaySelectedColor);
     }
 
     /* (non-Javadoc)
@@ -790,6 +809,10 @@ public class JDatePanel extends JComponent implements DatePanel {
                         && todayCal.get(Calendar.MONTH) == internalModel.getModel().getMonth()
                         && todayCal.get(Calendar.YEAR) == internalModel.getModel().getYear()) {
                     label.setForeground(getColors().getColor(ComponentColorDefaults.Key.FG_GRID_TODAY));
+                    
+                    //set border (null allowed):
+                    label.setBorder(todayMarkingBorder);
+                    
                     //Selected
                     if (internalModel.getModel().isSelected() && selectedCal.get(Calendar.DATE) == cellDayValue) {
                         label.setForeground(getColors().getColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED));

--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -273,6 +273,10 @@ public class JDatePicker extends JComponent implements DatePicker {
         datePanel.setShowYearButtons(showYearButtons);
     }
 
+    public void setTodayMarkingBorder (Color color){
+        datePanel.setTodayMarkingBorder(color);
+    }
+    
     private void setTextFieldValue(JFormattedTextField textField, int year, int month, int day, boolean isSelected) {
         if (!isSelected) {
             textField.setValue(null);

--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -54,7 +54,7 @@ import java.util.Set;
  * @author JC Oosthuizen
  * @author Yue Huang
  */
-public class JDatePicker extends JComponent implements DatePicker {
+public class JDatePicker extends DatePicker {
 
     private static final long serialVersionUID = 2814777654384974503L;
 
@@ -265,10 +265,6 @@ public class JDatePicker extends JComponent implements DatePicker {
         return datePanel.isShowYearButtons();
     }
 
-    public boolean isShowTodayBorder() {
-        return datePanel.isShowTodayBorder();
-    }
-
     public void setDoubleClickAction(boolean doubleClickAction) {
         datePanel.setDoubleClickAction(doubleClickAction);
     }
@@ -277,10 +273,6 @@ public class JDatePicker extends JComponent implements DatePicker {
         datePanel.setShowYearButtons(showYearButtons);
     }
 
-    public void setStaticTodayBorder (boolean showTodayBorder){
-        datePanel.setStaticTodayBorder(showTodayBorder);
-    }
-    
     private void setTextFieldValue(JFormattedTextField textField, int year, int month, int day, boolean isSelected) {
         if (!isSelected) {
             textField.setValue(null);

--- a/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/src/main/java/org/jdatepicker/JDatePicker.java
@@ -265,6 +265,10 @@ public class JDatePicker extends JComponent implements DatePicker {
         return datePanel.isShowYearButtons();
     }
 
+    public boolean isShowTodayBorder() {
+        return datePanel.isShowTodayBorder();
+    }
+
     public void setDoubleClickAction(boolean doubleClickAction) {
         datePanel.setDoubleClickAction(doubleClickAction);
     }
@@ -273,8 +277,8 @@ public class JDatePicker extends JComponent implements DatePicker {
         datePanel.setShowYearButtons(showYearButtons);
     }
 
-    public void setTodayMarkingBorder (Color color){
-        datePanel.setTodayMarkingBorder(color);
+    public void setStaticTodayBorder (boolean showTodayBorder){
+        datePanel.setStaticTodayBorder(showTodayBorder);
     }
     
     private void setTextFieldValue(JFormattedTextField textField, int year, int month, int day, boolean isSelected) {

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -29,9 +29,9 @@ public class Feature11 {
         datePanelDisabled.setEnabled(false);
         
         final JDatePanel datePanelExp = new JDatePanel();
-        //not the right way (because the border couldn't be disabled 
-        //only for the instance, it will be overriden by the following setting 
-        //of border):
+        //instance using a static method is not the right way but would work
+        //(anyway the border couldn't be disabled only for the instance, 
+        //this will be overriden by the subsequent setting of border):
         datePanelExp.setTodayBorder(false);
 
         /* As the border is a static feature (just like the colored today number)

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -1,0 +1,39 @@
+package org.jdatepicker.features;
+
+import java.awt.Color;
+import java.awt.Component;
+import org.jdatepicker.JDatePicker;
+
+import javax.swing.*;
+
+/**
+ * a. Add a red border that is marking today.
+ * 
+ */
+public class Feature11 {
+
+    public static void main(final String[] args) {
+        // Create a frame
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setSize(550, 300);
+
+        // Create a flow layout panel
+        final JPanel jPanel = new JPanel();
+        frame.getContentPane().add(jPanel);
+
+        // Create the JDatePicker
+        final JDatePicker jDatePicker = new JDatePicker();
+        
+        //Set a red border marking today for JDatePicker
+        jDatePicker.setTodayMarkingBorder(Color.RED);
+        
+        // add the internal DatePanel to the layout panel of the frame
+        jPanel.add((Component)jDatePicker.getJDateInstantPanel());
+
+        // Make the frame visible
+        frame.setVisible(true);
+
+    }
+
+}

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -2,6 +2,7 @@ package org.jdatepicker.features;
 
 
 import javax.swing.*;
+import org.jdatepicker.DatePanel;
 import org.jdatepicker.JDatePanel;
 
 /**
@@ -20,28 +21,29 @@ public class Feature11 {
         final JPanel jPanel = new JPanel();
         frame.getContentPane().add(jPanel);
 
-        JDatePanel.setTodayBorder(true);
-        // Create a first JDatePanel without a border that is marking today.
-        // As the border is a static feature (just like a colored today number)
-        // a border is still displayed because it is subsequently set. 
+        // Create a JDatePanel
         final JDatePanel datePanel = new JDatePanel();
-        datePanel.setTodayBorder(true);
+        
+        // Create a disabled JDatePanel
+        final JDatePanel datePanelDisabled = new JDatePanel();
+        datePanelDisabled.setEnabled(false);
+        
+        final JDatePanel datePanelExp = new JDatePanel();
+        //not the right way (because the border couldn't be disabled 
+        //only for the instance, it will be overriden by the following setting 
+        //of border):
+        datePanelExp.setTodayBorder(false);
 
-        // Create a second JDatePanel with border marking today
-        final JDatePanel datePanelWithBorder = new JDatePanel();
-        //Set a border marking today in DatePanel
-        datePanelWithBorder.setTodayBorder(true);
+        /* As the border is a static feature (just like the colored today number)
+         * a border is displayed for all instances in a runtime. 
+         */
+        DatePanel.setTodayBorder(true);
+//        DatePanel.setTodayBorder(false);
         
-        // Create a third JDatePanel with border marking today but disabled
-        final JDatePanel datePanelWithBorderDis = new JDatePanel();
-        //Statically setting a border in DatePanel is redundant:
-        datePanelWithBorderDis.setTodayBorder(true);
-        datePanelWithBorderDis.setEnabled(false);
-        
-        // add the DatePanel to the layout panel of the frame
+        // add the DatePanels to the layout panel of the frame
         jPanel.add(datePanel);
-        jPanel.add(datePanelWithBorder);
-        jPanel.add(datePanelWithBorderDis);
+        jPanel.add(datePanelExp);
+        jPanel.add(datePanelDisabled);
 
         // Make the frame visible
         frame.setVisible(true);

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -20,20 +20,22 @@ public class Feature11 {
         final JPanel jPanel = new JPanel();
         frame.getContentPane().add(jPanel);
 
+        JDatePanel.setTodayBorder(true);
         // Create a first JDatePanel without a border that is marking today.
         // As the border is a static feature (just like a colored today number)
         // a border is still displayed because it is subsequently set. 
         final JDatePanel datePanel = new JDatePanel();
-        
+        datePanel.setTodayBorder(true);
+
         // Create a second JDatePanel with border marking today
         final JDatePanel datePanelWithBorder = new JDatePanel();
         //Set a border marking today in DatePanel
-        datePanelWithBorder.setStaticTodayBorder(true);
+        datePanelWithBorder.setTodayBorder(true);
         
         // Create a third JDatePanel with border marking today but disabled
         final JDatePanel datePanelWithBorderDis = new JDatePanel();
         //Statically setting a border in DatePanel is redundant:
-        datePanelWithBorderDis.setStaticTodayBorder(true);
+        datePanelWithBorderDis.setTodayBorder(true);
         datePanelWithBorderDis.setEnabled(false);
         
         // add the DatePanel to the layout panel of the frame

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -1,10 +1,8 @@
 package org.jdatepicker.features;
 
-import java.awt.Color;
-import java.awt.Component;
-import org.jdatepicker.JDatePicker;
 
 import javax.swing.*;
+import org.jdatepicker.JDatePanel;
 
 /**
  * a. Add a red border that is marking today.
@@ -16,20 +14,32 @@ public class Feature11 {
         // Create a frame
         final JFrame frame = new JFrame();
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-        frame.setSize(550, 300);
+        frame.setSize(680, 300);
 
         // Create a flow layout panel
         final JPanel jPanel = new JPanel();
         frame.getContentPane().add(jPanel);
 
-        // Create the JDatePicker
-        final JDatePicker jDatePicker = new JDatePicker();
+        // Create a first JDatePanel without a border that is marking today.
+        // As the border is a static feature (just like a colored today number)
+        // a border is still displayed because it is subsequently set. 
+        final JDatePanel datePanel = new JDatePanel();
         
-        //Set a red border marking today for JDatePicker
-        jDatePicker.setTodayMarkingBorder(Color.RED);
+        // Create a second JDatePanel with border marking today
+        final JDatePanel datePanelWithBorder = new JDatePanel();
+        //Set a border marking today in DatePanel
+        datePanelWithBorder.setStaticTodayBorder(true);
         
-        // add the internal DatePanel to the layout panel of the frame
-        jPanel.add((Component)jDatePicker.getJDateInstantPanel());
+        // Create a third JDatePanel with border marking today but disabled
+        final JDatePanel datePanelWithBorderDis = new JDatePanel();
+        //Statically setting a border in DatePanel is redundant:
+        datePanelWithBorderDis.setStaticTodayBorder(true);
+        datePanelWithBorderDis.setEnabled(false);
+        
+        // add the DatePanel to the layout panel of the frame
+        jPanel.add(datePanel);
+        jPanel.add(datePanelWithBorder);
+        jPanel.add(datePanelWithBorderDis);
 
         // Make the frame visible
         frame.setVisible(true);


### PR DESCRIPTION
Hola Juan!
In many countries, a red number indicates a celebration day or a Sunday.
That's why I had the idea of an alternative marking for today:
this new feature(11) puts a border around the number of today with a
a specified color. This Contribution uses a static methods because the
today's mark is a static feature. It is valid for all instances in a runtime. 
Hasta luego!
Ralf