### PR TITLE
New feature: marking today with border.

### DIFF
--- a/src/main/java/org/jdatepicker/ComponentColorDefaults.java
+++ b/src/main/java/org/jdatepicker/ComponentColorDefaults.java
@@ -59,7 +59,8 @@ public final class ComponentColorDefaults {
         FG_TODAY_SELECTOR_ENABLED,
         FG_TODAY_SELECTOR_DISABLED,
         BG_TODAY_SELECTOR,
-        POPUP_BORDER;
+        POPUP_BORDER,
+        FG_GRID_TODAY_BORDER;
     }
 
     private Map<Key, Color> colors;
@@ -90,6 +91,8 @@ public final class ComponentColorDefaults {
         colors.put(Key.BG_TODAY_SELECTOR, Color.WHITE);
 
         colors.put(Key.POPUP_BORDER, Color.BLACK);
+
+        colors.put(Key.FG_GRID_TODAY_BORDER, Color.RED);
     }
 
     public Color getColor(Key key) {

--- a/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/src/main/java/org/jdatepicker/JDatePanel.java
@@ -795,6 +795,14 @@ public class JDatePanel extends JComponent implements DatePanel {
                         label.setForeground(getColors().getColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED));
                         label.setBackground(getColors().getColor(ComponentColorDefaults.Key.BG_GRID_TODAY_SELECTED));
                     }
+                    //Optionally mark today with a border
+                    if(TodayMark.isShowTodayBorder()&&isEnabled()){
+                        Color borderColor = getColors()
+                                .getColor(ComponentColorDefaults.Key.FG_GRID_TODAY_BORDER);
+                        label.setBorder(BorderFactory.createLineBorder(borderColor, 2));
+                    }else{
+                        label.setBorder(null);
+                    }
                 }
                 //Other day
                 else {

--- a/src/main/java/org/jdatepicker/TodayMark.java
+++ b/src/main/java/org/jdatepicker/TodayMark.java
@@ -1,0 +1,65 @@
+/**
+ Copyright 2004 Juan Heyns. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification, are
+ permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this list of
+ conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ of conditions and the following disclaimer in the documentation and/or other materials
+ provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY JUAN HEYNS ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JUAN HEYNS OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ The views and conclusions contained in the software and documentation are those of the
+ authors and should not be interpreted as representing official policies, either expressed
+ or implied, of Juan Heyns.
+ */
+package org.jdatepicker;
+
+import java.awt.Color;
+
+/**
+ *
+ * @author Ralf Buenemann
+ */
+public class TodayMark {
+    private static boolean showTodayBorder;
+
+    private TodayMark() {}
+    
+    public static final boolean isShowTodayBorder() {
+        return showTodayBorder;
+    }
+
+    public static final void setShowTodayBorder(boolean showTodayBorder) {
+        TodayMark.showTodayBorder = showTodayBorder;
+    }
+    
+    public static void setRedColorForTodayNumber(boolean isRed){
+        ComponentColorDefaults colors = ComponentColorDefaults.getInstance();
+        if(isRed){
+            colors.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, Color.RED);
+            colors.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, Color.RED);
+        }else{
+            Color everyDay = colors.getColor(ComponentColorDefaults.Key
+                    .FG_GRID_THIS_MONTH);
+            Color everyDaySelected = colors.getColor(ComponentColorDefaults.Key
+                    .FG_GRID_SELECTED);
+            colors.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY, everyDay);
+            colors.setColor(ComponentColorDefaults.Key.FG_GRID_TODAY_SELECTED, everyDaySelected);
+        }
+        
+    }
+    
+}

--- a/src/test/java/org/jdatepicker/features/Feature11.java
+++ b/src/test/java/org/jdatepicker/features/Feature11.java
@@ -1,0 +1,48 @@
+package org.jdatepicker.features;
+
+
+import javax.swing.*;
+import org.jdatepicker.TodayMark;
+import org.jdatepicker.JDatePanel;
+
+/**
+ * a. Add a red border that is marking today.
+ * 
+ */
+public class Feature11 {
+
+    public static void main(final String[] args) {
+        // Create a frame
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setSize(680, 300);
+
+        // Create a flow layout panel
+        final JPanel jPanel = new JPanel();
+        frame.getContentPane().add(jPanel);
+
+        // Create a JDatePanel
+        final JDatePanel datePanel = new JDatePanel();
+        
+        // Create a disabled JDatePanel
+        final JDatePanel datePanelDisabled = new JDatePanel();
+        datePanelDisabled.setEnabled(false);
+        
+        //Set a border marking today in DatePanels
+        TodayMark.setShowTodayBorder(true);
+        //Set color of today's number like every other day of this month
+        TodayMark.setRedColorForTodayNumber(false);
+        
+        // add the DatePanel to the layout panel of the frame
+        jPanel.add(datePanel);
+        jPanel.add(datePanelDisabled);
+        
+//        change color schema for today's number'
+    
+
+        // Make the frame visible
+        frame.setVisible(true);
+
+    }
+
+}


### PR DESCRIPTION
Hola Juan!
In many countries, a red number indicates a celebration day or a Sunday.
That's why I had the idea of an alternative marking for today:
this new feature(11) puts a red border around the number of today. 
It is valid for all instances in a runtime. I hope it fits in your concept :-)
Hasta luego!
Ralf