### PR TITLE
Add defensive null checks to constructors (improves #79)

### DIFF
--- a/library/src/main/java/org/jdatepicker/JDatePanel.java
+++ b/library/src/main/java/org/jdatepicker/JDatePanel.java
@@ -113,8 +113,11 @@ public class JDatePanel extends JComponent implements DatePanel {
      * Create a JDatePanel with a custom date model.
      *
      * @param model a custom date model
+     * @throws NullPointerException if model is null
      */
     public JDatePanel(DateModel<?> model) {
+        Objects.requireNonNull(model, "DateModel cannot be null");
+        
         actionListeners = new CopyOnWriteArraySet<ActionListener>();
         dateConstraints = new CopyOnWriteArraySet<DateSelectionConstraint>();
 

--- a/library/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/library/src/main/java/org/jdatepicker/JDatePicker.java
@@ -38,6 +38,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Calendar;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 

--- a/library/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/library/src/main/java/org/jdatepicker/JDatePicker.java
@@ -128,8 +128,11 @@ public class JDatePicker extends JComponent implements DatePicker {
      * Formatting is described at:
      *
      * @param datePanel The DatePanel to use
+     * @throws NullPointerException if datePanel is null
      */
     private JDatePicker(JDatePanel datePanel) {
+        Objects.requireNonNull(datePanel, "JDatePanel cannot be null");
+        
         this.datePanel = datePanel;
 
         //Initialise Variables


### PR DESCRIPTION
## Problem

When users pass `null` to constructors, they get confusing NPEs deep in the initialization code:

```java
JDatePanel panel = new JDatePanel(null); // NPE in InternalCalendarModel.constructor
```

The error doesn't clearly indicate that a null model was passed.

## Solution

Add `Objects.requireNonNull()` checks at the start of constructors:

```java
public JDatePanel(DateModel<?> model) {
    Objects.requireNonNull(model, "DateModel cannot be null");
    // ...
}
```

## Benefits

- **Clearer error messages**: "DateModel cannot be null" instead of cryptic NPE
- **Fail-fast**: Error occurs immediately at the call site, not deep in initialization
- **Better debugging**: Stack trace points to the actual problem

## Changes

- Added null check to `JDatePanel(DateModel<?> model)`
- Added null check to `JDatePicker(JDatePanel datePanel)`
- Added `@throws NullPointerException` to javadoc

## Related

#79 - While the original issue was user error, this improves the library's error handling when the API is misused.