### PR TITLE
Add java.time and java.util.Date convenience methods (closes #105, #106)

### DIFF
--- a/library/src/main/java/org/jdatepicker/JDatePicker.java
+++ b/library/src/main/java/org/jdatepicker/JDatePicker.java
@@ -349,6 +349,102 @@ public class JDatePicker extends JComponent implements DatePicker {
         super.removeNotify();
     }
 
+    // Convenience methods for java.util.Date and java.time support
+
+    /**
+     * Sets the selected date using a java.util.Date.
+     *
+     * @param date the Date to select, or null to clear the selection
+     */
+    public void setDate(java.util.Date date) {
+        if (date != null) {
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            datePanel.getModel().setDate(
+                    cal.get(Calendar.YEAR),
+                    cal.get(Calendar.MONTH),
+                    cal.get(Calendar.DAY_OF_MONTH)
+            );
+            datePanel.getModel().setSelected(true);
+        } else {
+            datePanel.getModel().setSelected(false);
+        }
+    }
+
+    /**
+     * Returns the selected date as java.util.Date, or null if nothing is selected.
+     *
+     * @return the selected date, or null
+     */
+    public java.util.Date getDate() {
+        DateModel<?> model = datePanel.getModel();
+        if (model.isSelected()) {
+            Calendar cal = Calendar.getInstance();
+            cal.set(model.getYear(), model.getMonth(), model.getDay(), 0, 0, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            return cal.getTime();
+        }
+        return null;
+    }
+
+    /**
+     * Sets the selected date using java.time.Instant.
+     *
+     * @param instant the Instant to select, or null to clear the selection
+     */
+    public void setInstant(java.time.Instant instant) {
+        if (instant != null) {
+            setDate(java.util.Date.from(instant));
+        } else {
+            datePanel.getModel().setSelected(false);
+        }
+    }
+
+    /**
+     * Gets the selected date as java.time.Instant.
+     *
+     * @return the selected date as Instant, or null if nothing is selected
+     */
+    public java.time.Instant getInstant() {
+        java.util.Date date = getDate();
+        return date != null ? date.toInstant() : null;
+    }
+
+    /**
+     * Sets the selected date using java.time.LocalDate.
+     *
+     * @param localDate the LocalDate to select, or null to clear the selection
+     */
+    public void setLocalDate(java.time.LocalDate localDate) {
+        if (localDate != null) {
+            datePanel.getModel().setDate(
+                    localDate.getYear(),
+                    localDate.getMonthValue() - 1, // LocalDate months are 1-12, Calendar uses 0-11
+                    localDate.getDayOfMonth()
+            );
+            datePanel.getModel().setSelected(true);
+        } else {
+            datePanel.getModel().setSelected(false);
+        }
+    }
+
+    /**
+     * Gets the selected date as java.time.LocalDate.
+     *
+     * @return the selected date as LocalDate, or null if nothing is selected
+     */
+    public java.time.LocalDate getLocalDate() {
+        DateModel<?> model = datePanel.getModel();
+        if (model.isSelected()) {
+            return java.time.LocalDate.of(
+                    model.getYear(),
+                    model.getMonth() + 1, // Calendar months are 0-11, LocalDate uses 1-12
+                    model.getDay()
+            );
+        }
+        return null;
+    }
+
     /**
      * This internal class hides the public event methods from the outside
      */

--- a/library/src/test/java/org/jdatepicker/JDatePickerJavaTimeTest.java
+++ b/library/src/test/java/org/jdatepicker/JDatePickerJavaTimeTest.java
@@ -1,0 +1,213 @@
+package org.jdatepicker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for java.time and java.util.Date convenience methods in JDatePicker.
+ */
+public class JDatePickerJavaTimeTest {
+
+    private JDatePicker datePicker;
+
+    @BeforeEach
+    void setUp() {
+        datePicker = new JDatePicker();
+    }
+
+    @Test
+    void testSetAndGetDate() {
+        // Create a date: January 15, 2024
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+
+        // Set the date
+        datePicker.setDate(testDate);
+
+        // Verify it was set
+        assertTrue(datePicker.getModel().isSelected());
+        assertEquals(2024, datePicker.getModel().getYear());
+        assertEquals(Calendar.JANUARY, datePicker.getModel().getMonth());
+        assertEquals(15, datePicker.getModel().getDay());
+
+        // Get the date back
+        Date retrievedDate = datePicker.getDate();
+        assertNotNull(retrievedDate);
+        assertEquals(testDate, retrievedDate);
+    }
+
+    @Test
+    void testSetDateNull() {
+        // Set a date first
+        datePicker.setDate(new Date());
+        assertTrue(datePicker.getModel().isSelected());
+
+        // Set to null
+        datePicker.setDate(null);
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getDate());
+    }
+
+    @Test
+    void testGetDateWhenNotSelected() {
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getDate());
+    }
+
+    @Test
+    void testSetAndGetLocalDate() {
+        // Create a LocalDate: February 28, 2024
+        LocalDate testDate = LocalDate.of(2024, 2, 28);
+
+        // Set the date
+        datePicker.setLocalDate(testDate);
+
+        // Verify it was set
+        assertTrue(datePicker.getModel().isSelected());
+        assertEquals(2024, datePicker.getModel().getYear());
+        assertEquals(Calendar.FEBRUARY, datePicker.getModel().getMonth()); // Calendar uses 0-11
+        assertEquals(28, datePicker.getModel().getDay());
+
+        // Get the date back
+        LocalDate retrievedDate = datePicker.getLocalDate();
+        assertNotNull(retrievedDate);
+        assertEquals(testDate, retrievedDate);
+    }
+
+    @Test
+    void testSetLocalDateNull() {
+        // Set a date first
+        datePicker.setLocalDate(LocalDate.now());
+        assertTrue(datePicker.getModel().isSelected());
+
+        // Set to null
+        datePicker.setLocalDate(null);
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getLocalDate());
+    }
+
+    @Test
+    void testGetLocalDateWhenNotSelected() {
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getLocalDate());
+    }
+
+    @Test
+    void testLocalDateMonthConversion() {
+        // Test that month conversion between LocalDate (1-12) and Calendar (0-11) works correctly
+        for (int month = 1; month <= 12; month++) {
+            LocalDate testDate = LocalDate.of(2024, month, 15);
+            datePicker.setLocalDate(testDate);
+            
+            assertEquals(month - 1, datePicker.getModel().getMonth(), 
+                "Calendar month should be " + (month - 1) + " for LocalDate month " + month);
+            
+            LocalDate retrieved = datePicker.getLocalDate();
+            assertEquals(testDate, retrieved, 
+                "Retrieved LocalDate should match original for month " + month);
+        }
+    }
+
+    @Test
+    void testSetAndGetInstant() {
+        // Create an Instant
+        Instant testInstant = Instant.parse("2024-03-15T12:30:00Z");
+
+        // Set the instant
+        datePicker.setInstant(testInstant);
+
+        // Verify the date was set (time component should be stripped)
+        assertTrue(datePicker.getModel().isSelected());
+        
+        // Get as LocalDate to verify the date part
+        LocalDate expectedDate = testInstant.atZone(ZoneId.systemDefault()).toLocalDate();
+        LocalDate actualDate = datePicker.getLocalDate();
+        assertEquals(expectedDate, actualDate);
+
+        // Get the instant back
+        Instant retrievedInstant = datePicker.getInstant();
+        assertNotNull(retrievedInstant);
+        
+        // The time should be set to midnight in system timezone
+        assertEquals(expectedDate, retrievedInstant.atZone(ZoneId.systemDefault()).toLocalDate());
+    }
+
+    @Test
+    void testSetInstantNull() {
+        // Set an instant first
+        datePicker.setInstant(Instant.now());
+        assertTrue(datePicker.getModel().isSelected());
+
+        // Set to null
+        datePicker.setInstant(null);
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getInstant());
+    }
+
+    @Test
+    void testGetInstantWhenNotSelected() {
+        assertFalse(datePicker.getModel().isSelected());
+        assertNull(datePicker.getInstant());
+    }
+
+    @Test
+    void testConversionBetweenDateAndLocalDate() {
+        // Set using Date
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MARCH, 20, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date date = cal.getTime();
+        
+        datePicker.setDate(date);
+        
+        // Get as LocalDate
+        LocalDate localDate = datePicker.getLocalDate();
+        assertEquals(2024, localDate.getYear());
+        assertEquals(3, localDate.getMonthValue());
+        assertEquals(20, localDate.getDayOfMonth());
+        
+        // Now set using LocalDate
+        LocalDate newDate = LocalDate.of(2024, 4, 25);
+        datePicker.setLocalDate(newDate);
+        
+        // Get as Date
+        Date retrievedDate = datePicker.getDate();
+        Calendar retrievedCal = Calendar.getInstance();
+        retrievedCal.setTime(retrievedDate);
+        assertEquals(2024, retrievedCal.get(Calendar.YEAR));
+        assertEquals(Calendar.APRIL, retrievedCal.get(Calendar.MONTH));
+        assertEquals(25, retrievedCal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    @Test
+    void testLeapYearDate() {
+        // Test February 29, 2024 (leap year)
+        LocalDate leapDay = LocalDate.of(2024, 2, 29);
+        datePicker.setLocalDate(leapDay);
+        
+        assertEquals(leapDay, datePicker.getLocalDate());
+        assertEquals(29, datePicker.getModel().getDay());
+    }
+
+    @Test
+    void testDateRangeBoundaries() {
+        // Test minimum and maximum reasonable dates
+        LocalDate minDate = LocalDate.of(1900, 1, 1);
+        datePicker.setLocalDate(minDate);
+        assertEquals(minDate, datePicker.getLocalDate());
+        
+        LocalDate maxDate = LocalDate.of(2100, 12, 31);
+        datePicker.setLocalDate(maxDate);
+        assertEquals(maxDate, datePicker.getLocalDate());
+    }
+}


### PR DESCRIPTION
## Overview

Adds convenient getter/setter methods for modern Java date types, making it easier to use JDatePicker with `java.time` and `java.util.Date`.

## New Methods

### java.util.Date Support
```java
public void setDate(java.util.Date date)
public java.util.Date getDate()
```

### java.time.Instant Support
```java
public void setInstant(java.time.Instant instant)
public java.time.Instant getInstant()
```

### java.time.LocalDate Support (NEW!)
```java
public void setLocalDate(java.time.LocalDate localDate)
public java.time.LocalDate getLocalDate()
```

## Features

✅ **Proper month conversion** - Handles Calendar (0-11) ↔ LocalDate (1-12) correctly
✅ **Null handling** - Setting null clears the selection
✅ **Returns null** when no date is selected (consistent with `getValue()`)
✅ **Time normalization** - Time components set to midnight for date-only types
✅ **Round-trip conversion** - Can convert between all date types seamlessly

## Example Usage

```java
JDatePicker picker = new JDatePicker();

// Using LocalDate (most common for modern Java)
picker.setLocalDate(LocalDate.of(2024, 3, 15));
LocalDate date = picker.getLocalDate();

// Using Instant (for timestamps)
picker.setInstant(Instant.now());
Instant instant = picker.getInstant();

// Using java.util.Date (legacy support)
picker.setDate(new Date());
Date utilDate = picker.getDate();
```

## Tests

Comprehensive test coverage including:
- All getter/setter combinations
- Null handling
- Month conversion (Calendar 0-11 ↔ LocalDate 1-12)
- Leap year dates (Feb 29)
- Date range boundaries
- Round-trip conversions

## Relation to Existing PRs

This **supersedes PR #106** with:
- ✨ Additional `LocalDate` support (more commonly used than Instant)
- ✅ Full test coverage
- 🔧 Updated for current codebase structure

## Closes

#105 - java.time support
#106 - Instant and Date methods (superseded by this PR)